### PR TITLE
objc: fix binding test

### DIFF
--- a/objc/binding_test.go
+++ b/objc/binding_test.go
@@ -12,7 +12,7 @@ import (
 func TestGrammar(t *testing.T) {
 	assert := assert.New(t)
 
-	n, err := sitter.ParseCtx(context.Background(), []byte("int a = 2;"), c.GetLanguage())
+	n, err := sitter.ParseCtx(context.Background(), []byte("int a = 2;"), objc.GetLanguage())
 	assert.NoError(err)
 	assert.Equal(
 		"(translation_unit (declaration type: (primitive_type) declarator: (init_declarator declarator: (identifier) value: (number_literal))))",


### PR DESCRIPTION
Previously I didn't realize one needs to run `go test ./...` to run all the bindings tests too.