### PR TITLE
Add tree-sitter-zig Go binding into our fork of go-tree-sitter

### DIFF
--- a/_automation/grammars.json
+++ b/_automation/grammars.json
@@ -344,8 +344,10 @@
   {
     "language": "zig",
     "url": "https://github.com/maxxnino/tree-sitter-zig/",
-    "files":["parser.c"],
-    "reference": "master",
+    "files": [
+      "parser.c"
+    ],
+    "reference": "main",
     "revision": "2bac4cc6c697d46a193905fef6d003bfa0bfabfd",
     "updateBasedOn": "commit"
   }

--- a/_automation/grammars.json
+++ b/_automation/grammars.json
@@ -340,5 +340,13 @@
     "reference": "v0.5.0",
     "revision": "6129a83eeec7d6070b1c0567ec7ce3509ead607c",
     "updateBasedOn": "tag"
+  },
+  {
+    "language": "zig",
+    "url": "https://github.com/maxxnino/tree-sitter-zig/",
+    "files":["parser.c"],
+    "reference": "master",
+    "revision": "2bac4cc6c697d46a193905fef6d003bfa0bfabfd",
+    "updateBasedOn": "commit"
   }
 ]

--- a/zig/binding.go
+++ b/zig/binding.go
@@ -13,7 +13,11 @@ import (
 )
 
 // Get the tree-sitter Language for this grammar.
+func Language() unsafe.Pointer {
+	return unsafe.Pointer(C.tree_sitter_zig())
+}
+
+// yang: add this to make it work with what forge expects.
 func GetLanguage() *sitter.Language {
-	ptr := unsafe.Pointer(C.tree_sitter_zig())
-	return sitter.NewLanguage(ptr)
+	return sitter.NewLanguage(Language())
 }

--- a/zig/binding.go
+++ b/zig/binding.go
@@ -2,7 +2,7 @@ package zig
 
 // #cgo CFLAGS: -std=c11 -fPIC
 // #include "parser.h"
-//const TSLanguage *tree_sitter_zig();
+// const TSLanguage *tree_sitter_zig();
 // // NOTE: if your language has an external scanner, add it here.
 import "C"
 

--- a/zig/binding.go
+++ b/zig/binding.go
@@ -1,0 +1,19 @@
+package zig
+
+// #cgo CFLAGS: -std=c11 -fPIC
+// #include "parser.h"
+//const TSLanguage *tree_sitter_zig();
+// // NOTE: if your language has an external scanner, add it here.
+import "C"
+
+import (
+	"unsafe"
+
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+// Get the tree-sitter Language for this grammar.
+func GetLanguage() *sitter.Language {
+	ptr := unsafe.Pointer(C.tree_sitter_zig())
+	return sitter.NewLanguage(ptr)
+}

--- a/zig/binding_test.go
+++ b/zig/binding_test.go
@@ -1,0 +1,15 @@
+package zig_test
+
+import (
+	"testing"
+
+	tree_sitter "github.com/smacker/go-tree-sitter"
+	"github.com/smacker/go-tree-sitter/zig"
+)
+
+func TestCanLoadZigGrammar(t *testing.T) {
+	language := tree_sitter.NewLanguage(zig.Language())
+	if language == nil {
+		t.Errorf("Error loading Zig grammar")
+	}
+}

--- a/zig/binding_test.go
+++ b/zig/binding_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/smacker/go-tree-sitter/zig"
 )
 
-func TestCanLoadZigGrammar(t *testing.T) {
+func TestCanLoadGrammar(t *testing.T) {
 	language := tree_sitter.NewLanguage(zig.Language())
 	if language == nil {
 		t.Errorf("Error loading Zig grammar")

--- a/zig/parser.h
+++ b/zig/parser.h
@@ -1,0 +1,265 @@
+#ifndef TREE_SITTER_PARSER_H_
+#define TREE_SITTER_PARSER_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define ts_builtin_sym_error ((TSSymbol)-1)
+#define ts_builtin_sym_end 0
+#define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
+
+#ifndef TREE_SITTER_API_H_
+typedef uint16_t TSStateId;
+typedef uint16_t TSSymbol;
+typedef uint16_t TSFieldId;
+typedef struct TSLanguage TSLanguage;
+#endif
+
+typedef struct {
+  TSFieldId field_id;
+  uint8_t child_index;
+  bool inherited;
+} TSFieldMapEntry;
+
+typedef struct {
+  uint16_t index;
+  uint16_t length;
+} TSFieldMapSlice;
+
+typedef struct {
+  bool visible;
+  bool named;
+  bool supertype;
+} TSSymbolMetadata;
+
+typedef struct TSLexer TSLexer;
+
+struct TSLexer {
+  int32_t lookahead;
+  TSSymbol result_symbol;
+  void (*advance)(TSLexer *, bool);
+  void (*mark_end)(TSLexer *);
+  uint32_t (*get_column)(TSLexer *);
+  bool (*is_at_included_range_start)(const TSLexer *);
+  bool (*eof)(const TSLexer *);
+};
+
+typedef enum {
+  TSParseActionTypeShift,
+  TSParseActionTypeReduce,
+  TSParseActionTypeAccept,
+  TSParseActionTypeRecover,
+} TSParseActionType;
+
+typedef union {
+  struct {
+    uint8_t type;
+    TSStateId state;
+    bool extra;
+    bool repetition;
+  } shift;
+  struct {
+    uint8_t type;
+    uint8_t child_count;
+    TSSymbol symbol;
+    int16_t dynamic_precedence;
+    uint16_t production_id;
+  } reduce;
+  uint8_t type;
+} TSParseAction;
+
+typedef struct {
+  uint16_t lex_state;
+  uint16_t external_lex_state;
+} TSLexMode;
+
+typedef union {
+  TSParseAction action;
+  struct {
+    uint8_t count;
+    bool reusable;
+  } entry;
+} TSParseActionEntry;
+
+typedef struct {
+  int32_t start;
+  int32_t end;
+} TSCharacterRange;
+
+struct TSLanguage {
+  uint32_t version;
+  uint32_t symbol_count;
+  uint32_t alias_count;
+  uint32_t token_count;
+  uint32_t external_token_count;
+  uint32_t state_count;
+  uint32_t large_state_count;
+  uint32_t production_id_count;
+  uint32_t field_count;
+  uint16_t max_alias_sequence_length;
+  const uint16_t *parse_table;
+  const uint16_t *small_parse_table;
+  const uint32_t *small_parse_table_map;
+  const TSParseActionEntry *parse_actions;
+  const char * const *symbol_names;
+  const char * const *field_names;
+  const TSFieldMapSlice *field_map_slices;
+  const TSFieldMapEntry *field_map_entries;
+  const TSSymbolMetadata *symbol_metadata;
+  const TSSymbol *public_symbol_map;
+  const uint16_t *alias_map;
+  const TSSymbol *alias_sequences;
+  const TSLexMode *lex_modes;
+  bool (*lex_fn)(TSLexer *, TSStateId);
+  bool (*keyword_lex_fn)(TSLexer *, TSStateId);
+  TSSymbol keyword_capture_token;
+  struct {
+    const bool *states;
+    const TSSymbol *symbol_map;
+    void *(*create)(void);
+    void (*destroy)(void *);
+    bool (*scan)(void *, TSLexer *, const bool *symbol_whitelist);
+    unsigned (*serialize)(void *, char *);
+    void (*deserialize)(void *, const char *, unsigned);
+  } external_scanner;
+  const TSStateId *primary_state_ids;
+};
+
+static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
+  uint32_t index = 0;
+  uint32_t size = len - index;
+  while (size > 1) {
+    uint32_t half_size = size / 2;
+    uint32_t mid_index = index + half_size;
+    TSCharacterRange *range = &ranges[mid_index];
+    if (lookahead >= range->start && lookahead <= range->end) {
+      return true;
+    } else if (lookahead > range->end) {
+      index = mid_index;
+    }
+    size -= half_size;
+  }
+  TSCharacterRange *range = &ranges[index];
+  return (lookahead >= range->start && lookahead <= range->end);
+}
+
+/*
+ *  Lexer Macros
+ */
+
+#ifdef _MSC_VER
+#define UNUSED __pragma(warning(suppress : 4101))
+#else
+#define UNUSED __attribute__((unused))
+#endif
+
+#define START_LEXER()           \
+  bool result = false;          \
+  bool skip = false;            \
+  UNUSED                        \
+  bool eof = false;             \
+  int32_t lookahead;            \
+  goto start;                   \
+  next_state:                   \
+  lexer->advance(lexer, skip);  \
+  start:                        \
+  skip = false;                 \
+  lookahead = lexer->lookahead;
+
+#define ADVANCE(state_value) \
+  {                          \
+    state = state_value;     \
+    goto next_state;         \
+  }
+
+#define ADVANCE_MAP(...)                                              \
+  {                                                                   \
+    static const uint16_t map[] = { __VA_ARGS__ };                    \
+    for (uint32_t i = 0; i < sizeof(map) / sizeof(map[0]); i += 2) {  \
+      if (map[i] == lookahead) {                                      \
+        state = map[i + 1];                                           \
+        goto next_state;                                              \
+      }                                                               \
+    }                                                                 \
+  }
+
+#define SKIP(state_value) \
+  {                       \
+    skip = true;          \
+    state = state_value;  \
+    goto next_state;      \
+  }
+
+#define ACCEPT_TOKEN(symbol_value)     \
+  result = true;                       \
+  lexer->result_symbol = symbol_value; \
+  lexer->mark_end(lexer);
+
+#define END_STATE() return result;
+
+/*
+ *  Parse Table Macros
+ */
+
+#define SMALL_STATE(id) ((id) - LARGE_STATE_COUNT)
+
+#define STATE(id) id
+
+#define ACTIONS(id) id
+
+#define SHIFT(state_value)            \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .state = (state_value)          \
+    }                                 \
+  }}
+
+#define SHIFT_REPEAT(state_value)     \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .state = (state_value),         \
+      .repetition = true              \
+    }                                 \
+  }}
+
+#define SHIFT_EXTRA()                 \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .extra = true                   \
+    }                                 \
+  }}
+
+#define REDUCE(symbol_name, children, precedence, prod_id) \
+  {{                                                       \
+    .reduce = {                                            \
+      .type = TSParseActionTypeReduce,                     \
+      .symbol = symbol_name,                               \
+      .child_count = children,                             \
+      .dynamic_precedence = precedence,                    \
+      .production_id = prod_id                             \
+    },                                                     \
+  }}
+
+#define RECOVER()                    \
+  {{                                 \
+    .type = TSParseActionTypeRecover \
+  }}
+
+#define ACCEPT_INPUT()              \
+  {{                                \
+    .type = TSParseActionTypeAccept \
+  }}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TREE_SITTER_PARSER_H_


### PR DESCRIPTION
This changes adds Zig into our fork of go-tree-sitter, thanks to @psarna for pointing me this direction, much better than adding a git_repository of the tree-sitter-zig directly into forge.

The following files are copied from https://github.com/maxxnino/tree-sitter-zig/:
binding.go
binding_test.go
parser.h
parser.c

I made some small changes to a couple of them to make it build + making the style look similar to the rest of tree-sitter-go language subdirs

# Test plan:

go test -v ./...
This passed. (It doesn't test much, just the binding_test.go can work i guess.)

More importantly, I changed the go.mod in my local Forge checkout to point to my local go-tree-sitter and added "initLang(l, zig.GetLanguage(), langs.LangZig)" into queries.go, updated lang.go to MustCreate("zig") as well as Bazel deps. After that bazel build passed in forge. I think that's a good sign (still need a zig.scm to pass test in Forge but that will be a separate PR in forge)