### PR TITLE
php: fix uninitialized memory access

### DIFF
--- a/php/scanner.h
+++ b/php/scanner.h
@@ -158,7 +158,7 @@ static void deserialize(Scanner *scanner, const char *buffer, unsigned length) {
 
     uint8_t open_heredoc_count = buffer[size++];
     for (unsigned j = 0; j < open_heredoc_count; j++) {
-        Heredoc heredoc;
+        Heredoc heredoc = {0};
         heredoc.end_word_indentation_allowed = buffer[size++];
         heredoc.word = string_new();
         uint8_t word_length = buffer[size++];
@@ -535,7 +535,7 @@ static bool scan(Scanner *scanner, TSLexer *lexer, const bool *valid_symbols) {
 
     if (valid_symbols[HEREDOC_START]) {
         lexer->result_symbol = HEREDOC_START;
-        Heredoc heredoc;
+        Heredoc heredoc = {0};
 
         while (iswspace(lexer->lookahead)) {
             skip(lexer);


### PR DESCRIPTION
The boolean field in Heredoc was left initialized, and later accessed. The uninitialized access was detected even though this struct is memcpy'd to another location, so kudos to UBSAN!